### PR TITLE
Fixes #61 for V15

### DIFF
--- a/erpnextfints/utils/install.py
+++ b/erpnextfints/utils/install.py
@@ -6,8 +6,6 @@ from __future__ import unicode_literals
 
 import frappe
 from frappe import _
-from frappe.core.doctype.file.file import create_new_folder
-
 
 def before_install():  # noqa: D103
     if frappe.utils.sys.version_info.major < 3:
@@ -17,5 +15,11 @@ def before_install():  # noqa: D103
 def after_install():  # noqa: D103
     folder = 'Home/Attachments'
     foldername = 'FinTS'
-    if not frappe.db.exists('File', {'name': "/".join([folder, foldername])}):
-        create_new_folder(foldername, folder)
+    if not frappe.db.exists("File", {"file_name": foldername, "is_folder": True, "folder": folder}):
+        folder = frappe.get_doc({
+            "doctype": "File",
+            "file_name": foldername,
+            "is_folder": True,
+            "folder": folder
+        })
+        folder.insert()


### PR DESCRIPTION
Refers to issue #61 
Somehow frappe.core.doctype.file.file.create_new_folder doesn't seem importable in V15 (maybe in V14 too, didn't test that), which caused an error at install-app since after_install() is called there to create a folder Home/Attachments/FinTS.
Changed the way creating the folder by creating a new frappe.Document with frappe.get_doc()
After this, I could install it and access all DocTypes. Couldn't test the functionality itself because I'm still waiting for my product ID from FinTS.