### PR TITLE
feat: Added tan prompts

### DIFF
--- a/erpnextfints/erpnextfints/doctype/fints_import/fints_import.py
+++ b/erpnextfints/erpnextfints/doctype/fints_import/fints_import.py
@@ -19,9 +19,11 @@ class FinTSImport(Document):
                 _("'{0}' needs to be in the past").format(field_name)
             )
             return False
-        if (now_datetime().date() - date).days >= 90:
+
+        fints_login_doc = frappe.get_doc("FinTS Login", self.fints_login)
+        if (now_datetime().date() - date).days >= fints_login_doc.allowed_sync_days_in_past:
             frappe.msgprint(
-                _("'{0}' is more then 90 days in the past").format(field_name)
+                _("'{0}' is more then {1} days in the past").format(field_name, fints_login_doc.allowed_sync_days_in_past)
             )
             return False
         return True

--- a/erpnextfints/erpnextfints/doctype/fints_login/fints_login.json
+++ b/erpnextfints/erpnextfints/doctype/fints_login/fints_login.json
@@ -18,6 +18,11 @@
   "get_accounts",
   "account_iban",
   "failed_connection",
+  "column_break_ydzf",
+  "dialog_state_updated",
+  "client_state_updated",
+  "tan_state_updated",
+  "stored_tan_state_decoupled",
   "erpnext_account_settings_section",
   "company",
   "erpnext_account",
@@ -30,7 +35,10 @@
   "column_break_20",
   "enable_pay",
   "hidden_section",
-  "iban_list"
+  "iban_list",
+  "stored_client_state",
+  "stored_dialog_state",
+  "stored_tan_state"
  ],
  "fields": [
   {
@@ -174,14 +182,60 @@
    "fieldname": "product_id",
    "fieldtype": "Data",
    "label": "Product Id"
+  },
+  {
+   "fieldname": "tan_state_updated",
+   "fieldtype": "Datetime",
+   "label": "TAN State Updated",
+   "read_only": 1
+  },
+  {
+   "fieldname": "dialog_state_updated",
+   "fieldtype": "Datetime",
+   "label": "Dialog State Updated",
+   "read_only": 1
+  },
+  {
+   "fieldname": "stored_dialog_state",
+   "fieldtype": "Small Text",
+   "label": "Stored Dialog State"
+  },
+  {
+   "fieldname": "stored_tan_state",
+   "fieldtype": "Small Text",
+   "label": "Stored TAN State"
+  },
+  {
+   "fieldname": "client_state_updated",
+   "fieldtype": "Datetime",
+   "label": "Client State Updated",
+   "read_only": 1
+  },
+  {
+   "fieldname": "stored_client_state",
+   "fieldtype": "Small Text",
+   "label": "Stored Client State"
+  },
+  {
+   "fieldname": "column_break_ydzf",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "depends_on": "tan_state_updated",
+   "fieldname": "stored_tan_state_decoupled",
+   "fieldtype": "Check",
+   "label": "TAN State Decoupled",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-university",
  "links": [],
- "modified": "2023-07-04 09:54:48.833536",
+ "modified": "2025-01-25 13:38:38.237304",
  "modified_by": "Administrator",
  "module": "ERPNextFinTS",
  "name": "FinTS Login",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -206,5 +260,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "ASC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnextfints/erpnextfints/doctype/fints_login/fints_login.json
+++ b/erpnextfints/erpnextfints/doctype/fints_login/fints_login.json
@@ -18,6 +18,7 @@
   "get_accounts",
   "account_iban",
   "failed_connection",
+  "allowed_sync_days_in_past",
   "column_break_ydzf",
   "dialog_state_updated",
   "client_state_updated",
@@ -227,11 +228,18 @@
    "fieldtype": "Check",
    "label": "TAN State Decoupled",
    "read_only": 1
+  },
+  {
+   "default": "90",
+   "depends_on": "account_iban",
+   "fieldname": "allowed_sync_days_in_past",
+   "fieldtype": "Int",
+   "label": "Allowed Sync Days in the Past"
   }
  ],
  "icon": "fa fa-university",
  "links": [],
- "modified": "2025-01-25 13:38:38.237304",
+ "modified": "2025-01-27 22:00:24.021697",
  "modified_by": "Administrator",
  "module": "ERPNextFinTS",
  "name": "FinTS Login",

--- a/erpnextfints/erpnextfints/doctype/fints_login/fints_login.py
+++ b/erpnextfints/erpnextfints/doctype/fints_login/fints_login.py
@@ -4,8 +4,88 @@
 
 from __future__ import unicode_literals
 
+import base64
+
+import frappe
 from frappe.model.document import Document
+from frappe.utils.password import decrypt, encrypt
 
 
 class FinTSLogin(Document):
-    pass
+    def clear_fints_caches(self):
+        self.stored_client_blob = None
+        self.stored_dialog_blob = None
+        self.stored_tan_blob = None
+        self.stored_tan_state_decoupled = None
+        self.iban_list = None
+        self.account_iban = None
+
+    @property
+    def stored_client_blob(self):
+        return self.read_crypted_string_to_blob(self.stored_client_state)
+
+    @stored_client_blob.setter
+    def stored_client_blob(self, value: bytes):
+        self.client_state_updated = frappe.utils.now_datetime() if value else None
+        self.stored_client_state = self.conv_blob_to_encrypted_string(value)
+
+    @property
+    def stored_dialog_blob(self):
+        return self.read_crypted_string_to_blob(self.stored_dialog_state)
+
+    @stored_dialog_blob.setter
+    def stored_dialog_blob(self, value: bytes):
+        self.dialog_state_updated = frappe.utils.now_datetime() if value else None
+        self.stored_dialog_state = self.conv_blob_to_encrypted_string(value)
+
+    @property
+    def stored_tan_blob(self):
+        return self.read_crypted_string_to_blob(self.stored_tan_state)
+
+    @stored_tan_blob.setter
+    def stored_tan_blob(self, value: bytes):
+        self.tan_state_updated = frappe.utils.now_datetime() if value else None
+        self.stored_tan_state = self.conv_blob_to_encrypted_string(value)
+
+    def read_crypted_string_to_blob(self, encoded_encrypted_string: str) -> bytes | None:
+        """Decrypts ascii base64, and decrypts result to return blob"""
+        if not encoded_encrypted_string:
+            return None
+
+        # decrypt to base64 string
+        blob_str = decrypt(encoded_encrypted_string)
+
+        # decode base64 string to blob
+        return base64.b64decode(blob_str)
+
+    def conv_blob_to_encrypted_string(self, blob: bytes) -> str | None:
+        """Encrypts blob, and converts to ascii base64"""
+        if not blob:
+            return None
+
+        # convert blob to base64 string
+        blob_str = base64.b64encode(blob).decode()
+
+        # encrypt the base64-blob-string
+        return encrypt(blob_str)
+
+    @frappe.whitelist(allow_guest=False)
+    def reset_connection(self):
+        frappe.has_permission(ptype="write", doc=self, throw=True)
+        self.clear_fints_caches()
+        self.save()
+
+    # TODO
+    # @frappe.whitelist(allow_guest=False)
+    # def solve_tan_challenge(self, tan: str | None=''):
+    #     """
+    #     If a tan was requested in a background task or some other previous status, the socket prompt might not have
+    #     been shown. This method allows to trigger the challenge again to solve it.
+    #     """
+    #     frappe.has_permission(ptype="write", doc=self, throw=True)
+
+    #     from erpnextfints.utils.fints_controller import FinTSController
+
+    #     # Just init the FintsController instance should be enough to check for a tan challenge and make it continue:
+    #     # TAN will be requested via socket communication during initialization time.
+    #     FinTSController(self.name, {"docname": self.name, "enabled": True})

--- a/erpnextfints/public/js/controllers/fints_interactive.js
+++ b/erpnextfints/public/js/controllers/fints_interactive.js
@@ -4,18 +4,149 @@
 frappe.provide("erpnextfints.interactive");
 
 erpnextfints.interactive = {
+	updateQueue: Promise.resolve(),
+
+	enqueueUpdate: function(fn, delay) {
+		this.updateQueue = this.updateQueue
+			.then(() => {
+				// call the function
+				return Promise.resolve(fn());
+			})
+			.then(() => {
+				// delay the next update
+				return new Promise((resolve) => setTimeout(resolve, delay || 500));
+			});
+
+		return this.updateQueue;
+	},
+
 	progressbar: function(frm) {
+		frappe.realtime.off("fints_progressbar");
 		frappe.realtime.on("fints_progressbar", function(data) {
 			if(data.docname === frm.doc.name) {
-				if(data.reload && data.reload === true) {
-					frm.reload_doc();
-				}
-				if(data.progress==100) {
-					frappe.hide_progress();
-				} else {
-					frappe.show_progress(data.docname,data.progress,100,data.message);
+
+				erpnextfints.interactive.enqueueUpdate(() => {
+					if(data.progress==100) {
+						frappe.hide_progress();
+					} else {
+						frappe.show_progress(data.docname,data.progress,100,data.message);
+					}
+
+					if(data.reload && data.reload === true) {
+						// reload with short delay, to have progress update come active before
+						erpnextfints.interactive.enqueueUpdate(() => {
+							frm.reload_doc()
+						}, 500);
+					}
+				});
+			}
+		});
+
+		/**
+		 * Handle TAN interaction requirements for several steps:
+		 * 1. TAN Mode selection
+		 * 1.2. TAN Medium selection (if available)
+		 * 2. Later User Interaction after Push TAN fulfillment or TAN entered
+		 */
+		frappe.realtime.off("fints_tan_interaction_required");
+		frappe.realtime.on("fints_tan_interaction_required", async function(data) {
+			if(data.docname !== frm.doc.name) {
+				return;
+			}
+
+			await erpnextfints.interactive.enqueueUpdate(() => {
+				frappe.hide_progress();
+			});
+
+			let fields = [];
+
+			if (data.possible_tan_modes) {
+				fields.push(
+					{
+						fieldtype: "Select",
+						fieldname: "tan_mode",
+						label: __("TAN Mode"),
+						options: data.possible_tan_modes,
+						reqd: 1,
+					},
+				);
+
+				if (data.possible_tan_mediums) {
+					// if mediums are available for the selected mode, keep previously selected mode read-only
+					fields[0].default = data.possible_tan_modes[0];
+					fields[0].read_only = 1;
+
+					fields.push(
+						{
+							fieldtype: "Select",
+							fieldname: "tan_medium",
+							label: __("TAN Medium"),
+							options: data.possible_tan_mediums,
+							reqd: 1,
+						},
+					);
 				}
 			}
+
+			// TAN Mode selection
+			if (data.tan_required || data.mfa_required) {
+				if (data.possible_tan_modes && !fields[0].default) {
+					fields[0].default = data.possible_tan_modes[0];
+					fields[0].read_only = 1;
+				}
+
+				// if we're on confirmation already, keep previously selected mode read-only
+				if (data.possible_tan_mediums) {
+					const disableIdx = data.possible_tan_mediums ? 1 : 0;
+					fields[disableIdx].default = data.possible_tan_mediums[disableIdx];
+					fields[disableIdx].read_only = 1;
+				}
+
+				// User Interaction requirement for 2FA
+				fields.push(
+					{
+						fieldtype: "Check",
+						fieldname: "mfa_confirmation",
+						label: __("Confirm MFA"),
+						default: 1,
+						hidden: 1,
+					},
+				);
+
+				if (data.tan_required) {
+					fields.push(
+						{
+							fieldtype: "Data",
+							fieldname: "tan",
+							label: __("TAN"),
+							reqd: 1,
+						},
+					);
+				} else if (data.mfa_required) {
+					fields.push(
+						{
+							fieldtype: "HTML",
+							fieldname: "waiting",
+							label: __("Waiting for Interaction"),
+							options: __("Follow the instructions on your banking app or device."),
+						},
+					);
+				}
+			}
+
+			frappe.prompt(
+				fields,
+				(values) => {
+					frappe.call({
+						method: "erpnextfints.utils.client.resolve_tan_interaction",
+						args: {
+							fints_login: frm.doc.name,
+							values: { ...data, ...values },
+						},
+					});
+				},
+				__("Verification required")
+			);
 		});
 	},
 }

--- a/erpnextfints/utils/fints_controller.py
+++ b/erpnextfints/utils/fints_controller.py
@@ -4,12 +4,13 @@
 
 from __future__ import unicode_literals
 
+import contextlib
 import frappe
 import json
 import mt940
 
 from dateutil.relativedelta import relativedelta
-from fints.client import FinTS3PinTanClient, FinTSClientMode
+from fints.client import FinTS3PinTanClient, FinTSClientMode, NeedTANResponse, NeedRetryResponse # , FinTSUnsupportedOperation
 
 from frappe import _
 from frappe.utils import now_datetime
@@ -21,27 +22,111 @@ from frappe.utils.file_manager import (
 from .import_payment import ImportPaymentEntry
 from .assign_payment_controller import AssignmentController
 
+class InitFailedException(Exception):
+    pass
+
+class TanInteractionRequired(InitFailedException):
+    pass
 
 class FinTSController:
-    def __init__(self, fints_login_docname, interactive=False):
+    def __init__(self, fints_login_docname:str, interactive:bool=False, tan_mode:str=None, tan_medium:str=None, tan:str=...):
         self.fints_login = frappe.get_doc("FinTS Login", fints_login_docname)
+
+        # If this is load during a user interaction, verify its permissions (ignore for scheduled background tasks)
+        if interactive and interactive["enabled"]:
+            frappe.has_permission(ptype="write", doc=self.fints_login, throw=True)
+
         self.name = self.fints_login.name
         self.interactive = FinTSInteractive(interactive)
+
         self.__init_fints_connection()
-        self.__init_tan_processing()
+
+        # If state is new and did not setup tan requirements, init tan mode (and probably ask user for mode and medium).
+        if self.__init_tan_mode(tan_mode, tan_medium, tan) is False:
+            raise TanInteractionRequired()
+
+        # If there is an open TAN request, try to fulfill it
+        if self.fints_login.stored_tan_blob:
+            with self.fints_connection.resume_dialog(self.fints_login.stored_dialog_blob):
+                tan_request = NeedRetryResponse.from_data(self.fints_login.stored_tan_blob)
+
+                # this decoupled setting is missing everywhere, so decoupled requests (like pushTAN 2.0) cannot be handled without this
+                tan_request.decoupled = self.fints_login.stored_tan_state_decoupled
+                self.fints_connection.init_tan_response = self.fints_connection.send_tan(tan_request, tan)
+
+                # on failure update status and skip
+                if self.is_tan_required_and_requested(self.fints_connection.init_tan_response):
+                    raise TanInteractionRequired()
+
+                # on success clear stored tan state
+                self.__persist_fints_state()
+
+        # After successful login/tan verification fetch available accounts if not already present
+        if self.__fetch_fints_accounts() is False:
+            raise InitFailedException()
+
+        # Afterwards the controller/connection is ready to go for further operations
+        if self.fints_login.failed_connection:
+            self.fints_login.failed_connection = 0
+            self.fints_login.save()
+
+        self.interactive.show_progress_realtime(
+           _("Connection established"), 100, reload=False
+        )
+
+    @contextlib.contextmanager
+    def trusted_client_context(self):
+        """
+        Opens the fints client context (will most likely generate a new fints dialog) and checks if a TAN is requested.
+        If so, it will be requested from the user and the context body will be skipped.
+        """
         with self.fints_connection:
-            self.__get_fints_accounts()
+            if self.is_tan_required_and_requested(self.fints_connection.init_tan_response):
+                raise TanInteractionRequired()
+
+            yield self.fints_connection
+
+    def is_tan_required_and_requested(self, response) -> bool:
+        """Checks the given response, if a TAN is required. If so, it is requested from the user.
+        :param response: The response object from the FinTS server
+        :return: True if a TAN is required (and requested), False otherwise
+        """
+        if isinstance(response, NeedTANResponse):
+            self.ask_for_tan(response)
+            return True
+
+        return False
+
+    def __persist_fints_state(self, tan_state=None, clear:bool=False):
+        """Persist the current client/dialog state to the database.
+        :param tan_state: An additional TAN state to persist if given.
+        :param clear: Reset all the stored states
+        :return: None
+        """
+        self.fints_login.stored_client_blob = self.fints_connection.deconstruct(including_private=True)
+
+        if tan_state and isinstance(tan_state, NeedTANResponse):
+            self.fints_login.stored_tan_blob = tan_state.get_data()
+            self.fints_login.stored_tan_state_decoupled = tan_state.decoupled
+            self.fints_login.stored_dialog_blob = self.fints_connection.pause_dialog()
+        else:
+            self.fints_login.stored_tan_blob = None
+            self.fints_login.stored_tan_state_decoupled = None
+            self.fints_login.stored_dialog_blob = None
+
+        self.fints_login.save()
 
     def __init_fints_connection(self):
         """Private: Initialise new fints connection.
 
         :return: None
         """
+        if hasattr(self, "fints_connection"):
+            return
+
         self.interactive.show_progress_realtime(
             _("Initialise connection"), 10, reload=False
         )
-        if hasattr(self, "fints_connection"):
-            return
 
         try:
             self.fints_connection = FinTS3PinTanClient(
@@ -51,55 +136,148 @@ class FinTSController:
                 self.fints_login.fints_url,
                 product_id=self.fints_login.product_id,
                 mode=FinTSClientMode.INTERACTIVE,
+                from_data=self.fints_login.stored_client_blob,
             )
         except Exception as e:
             frappe.throw(
                 _("Could not conntect to fints server with error<br>{0}").format(e)
             )
 
-    def __init_tan_processing(self):
-        """Show a progressbar on client side.
-
-        :todo: Implement PSD2 requirements
-        :return: None
+    def __init_tan_mode(self, tan_mode:str=None, tan_medium:str=None, tan:str=...) -> bool:
         """
-        self.interactive.show_progress_realtime(
-            _("Initialise TAN settings"), 20, reload=False
-        )
-        self.fints_connection.fetch_tan_mechanisms()
+        Initializes the TAN mode to use. If there are multiple TAN mechanisms available, the user is asked to choose one (if no choise is permitted).
 
-        if self.fints_connection.init_tan_response:
-            raise NotImplementedError
+        :param tan_mode: The name of the TAN mechanism to use (choice was already made, if permitted)
+        :param tan_medium: The name of the TAN medium (on several devices, ...) to use (choice was already made, if permitted)
+        :return bool: Indicates if initialization was complete or should be stopped (because user interaction is required)
+        """
+        if not self.fints_connection.get_current_tan_mechanism():
+            self.interactive.show_progress_realtime(
+                _("Initialise TAN settings"), 20, reload=False
+            )
 
-    def __get_fints_accounts(self):
+            self.fints_connection.fetch_tan_mechanisms()
+
+            mechanisms = self.fints_connection.get_tan_mechanisms().items()
+
+            if len(mechanisms) == 0:
+                frappe.throw(_("No TAN mechanisms available"))
+
+            mechanism_names = ["{p.security_function}: {p.name}".format(p=m[1]) for m in mechanisms]
+
+            # If there is only one tan mechanism available, use it without asking
+            if len(mechanisms) == 1:
+                tan_mode = mechanism_names[0]
+
+            if tan_mode and tan_mode in mechanism_names:
+                # set tan mechanism
+                selected_mode = list(mechanisms)[mechanism_names.index(tan_mode)]
+                self.fints_connection.set_tan_mechanism(selected_mode[0])
+            else:
+                # request tan mechanism from user
+                self.interactive.request_tan_mechanism(mechanism_names)
+                return False
+
+        # discover tan medium handling
+        if self.fints_connection.selected_tan_medium is None and self.fints_connection.is_tan_media_required():
+            m = self.fints_connection.get_tan_media() # this request can already trigger another TAN request, which is not cool, but for other banks this makes more sense hopefully
+            medium_names = None
+
+            if len(m[1]) == 1:
+                self.fints_connection.set_tan_medium(m[1][0])
+            elif len(m[1]) == 0:
+                # This is a workaround for when the dialog already contains return code 3955.
+                # This occurs with e.g. Sparkasse Heidelberg, which apparently does not require us to choose a
+                # medium for pushTAN but is totally fine with keeping "" as a TAN medium.
+                self.fints_connection.selected_tan_medium = ""
+            elif tan_medium and tan_medium in [mm.tan_medium_name for mm in m[1]]:
+                self.fints_connection.set_tan_medium(next(mm for mm in m[1] if mm.tan_medium_name == tan_medium))
+            else:
+                # Multiple tan media available. Prompt user
+                medium_names = []
+                for mm in m[1]:
+                    medium_names.append("Medium {p.tan_medium_name}: Phone no. {p.mobile_number_masked}, Last used {p.last_use}".format(p=mm))
+
+                self.interactive.request_tan_mechanism([tan_mode], medium_names)
+                return False
+
+            # if the request already claimed a tan, persist state and ask for tan
+            if self.fints_connection.init_tan_response and self.fints_connection._standing_dialog:
+                # (Only!) If the tan request opened a dialog, which can be paused for later (continue after user-interaction)
+                # If not, it needs to be skipped (leads to multiple requests on the phone, but there is now option to persist the state, and it works)
+                self.ask_for_tan(self.fints_connection.init_tan_response, possible_tan_modes=[tan_mode], possible_tan_mediums=medium_names)
+                return False
+
+        return True
+
+    def ask_for_tan(self, response, *, decoupled=None, possible_tan_modes=None, possible_tan_mediums=None):
+        if response:
+            self.__persist_fints_state(response)
+
+        if response.decoupled if decoupled is None else decoupled:
+            self.interactive.request_mfa_confirmation(possible_tan_modes=possible_tan_modes, possible_tan_mediums=possible_tan_mediums)
+        else:
+            self.interactive.request_tan(possible_tan_modes=possible_tan_modes, possible_tan_mediums=possible_tan_mediums)
+
+    def __fetch_fints_accounts(self) -> bool:
         """Fetch FinTS Accounts.
 
-        :return: None
+        :return: True on success. False or an exception otherwise.
         """
-        self.interactive.show_progress_realtime(
-            _("Loading accounts"), 30, reload=False
-        )
-        if not hasattr(self, 'fints_accounts'):
-            try:
-                self.fints_accounts = self.fints_connection.get_sepa_accounts()
-            except Exception as e:
-                frappe.throw(_(
-                    "Could not load sepa accounts with error:<br>{0}"
-                ).format(e))
+        if hasattr(self, 'fints_accounts'):
+            return True
+
+        if self.fints_login.iban_list:
+            self.fints_accounts = json.loads(self.fints_login.iban_list)
+            return True
+
+        try:
+            with self.trusted_client_context() as client:
+                self.interactive.show_progress_realtime(
+                    _("Loading accounts"), 30, reload=False
+                )
+
+                accounts_response = client.get_sepa_accounts()
+                if self.is_tan_required_and_requested(accounts_response):
+                    return False
+
+                self.fints_accounts = accounts_response
+                self.fints_login.iban_list = json.dumps([a._asdict() for a in self.fints_accounts])
+
+                # Reading the accounts is part of the first initialization. So after this was successful, the
+                # client state can be persisted for future use.
+                self.__persist_fints_state()
+
+                self.interactive.show_progress_realtime(
+                    _("Loading accounts completed"), 100, reload=True
+                )
+                return True
+
+        except TanInteractionRequired:
+            raise
+        except Exception as e:
+            frappe.throw(_(
+                "Could not load sepa accounts with error:<br>{0}"
+            ).format(e))
+
+        return False
 
     def __get_fints_account_by_key(self, key, value):
+        if not value:
+            return None
+
         try:
-            account = None
             for acc in self.fints_accounts:
-                if getattr(acc, key) == value:
-                    account = acc
-                    break
+                if acc.get(key) == value:
+                    return acc
+
         except AttributeError:
             frappe.throw(_(
                 "SEPA account object has no key '{0}'"
             ).format(key))
+
         # Account can be None
-        return account
+        return None
 
     @staticmethod
     def get_fints_import_file_content(fints_import):
@@ -134,9 +312,6 @@ class FinTSController:
 
         :return: List of SEPAAccount objects.
         """
-        self.interactive.show_progress_realtime(
-            _("Loading accounts completed"), 100, reload=False
-        )
         return self.fints_accounts
 
     def get_fints_account_by_iban(self, iban):
@@ -184,12 +359,15 @@ class FinTSController:
                 _("Start date more then 90 days in the past")
             )
 
-        with self.fints_connection:
-            account = self.get_fints_account_by_iban(
-                self.fints_login.account_iban)
+        with self.trusted_client_context() as client:
+            if account := self.get_fints_account_by_iban(self.fints_login.account_iban):
+                account = frappe._dict(account)
+            else:
+                return []
+
             return json.loads(
                 json.dumps(
-                    self.fints_connection.get_transactions(
+                    client.get_transactions(
                         account,
                         start_date,
                         end_date
@@ -314,5 +492,50 @@ class FinTSInteractive:
                     "progress": progress,
                     "docname": self.docname,
                     "message": message,
-                    "reload": False
+                    "reload": reload
                 }, user=frappe.session.user)
+
+    def request_tan_mechanism(self, possible_tan_modes=None, possible_tan_mediums=None):
+        """Request tan mechanism from user.
+
+        :param possible_tan_modes: List of tan mechanisms
+        :type mechanisms: list
+        :return: None
+        """
+        self.request_tan_prompt(possible_tan_modes, possible_tan_mediums)
+
+    def request_tan(self, possible_tan_modes=None, possible_tan_mediums=None):
+        """Request a TAN from user
+
+        :return: None
+        """
+        self.request_tan_prompt(possible_tan_modes, possible_tan_mediums, request_tan=True)
+
+    def request_mfa_confirmation(self, possible_tan_modes=None, possible_tan_mediums=None):
+        """Request a solved MFA challenge from the user
+
+        :return: None
+        """
+        self.request_tan_prompt(possible_tan_modes, possible_tan_mediums, request_mfa_confirmation=True)
+
+    def request_tan_prompt(self, possible_tan_modes, possible_tan_mediums=None, *, request_tan=False, request_mfa_confirmation=False):
+        """Request tan mechanism from user.
+
+        :param possible_tan_modes: List of tan mechanisms
+        :type mechanisms: list
+        :return: None
+        """
+        if self.enabled:
+            params = {
+                        "docname": self.docname,
+                        "possible_tan_modes": possible_tan_modes,
+                        "possible_tan_mediums": possible_tan_mediums,
+                    }
+
+            if request_tan:
+                params["tan_required"] = True
+
+            elif request_mfa_confirmation:
+                params["mfa_required"] = True
+
+            frappe.publish_realtime("fints_tan_interaction_required", params, user=frappe.session.user)


### PR DESCRIPTION
erpnextfints stopped working for me a few months ago, as a tan was then required from the bank (which might be the case for most banks now).

So I've taken #43 into account and enabled the prompts with it.

So for my required banking account it is working now with Mobile TAN (enter a TAN retrieved in the App) and Mobile TAN 2.0 (Accept connection on the App, without the use of a TAN).

There might be still problems with _tan_medium_ handling, as my bank has unusual effects here (it requires a TAN, before the first TAN challenge can be solved. This leads to an additional TAN request on the app, but can be ignored).

Following the docs, it should behave differently on other banks. But if the code is working then out-of-the box is not sure, but could, as I took the main part from pyfints docs example.